### PR TITLE
Bug fix for segmentation fault

### DIFF
--- a/symal.cpp
+++ b/symal.cpp
@@ -507,7 +507,7 @@ int main(int argc, char** argv)
       delete inp;
     }
     if (out != &std::cout) {
-      delete inp;
+      delete out;
     }
   } catch (const std::exception &e) {
     cerr << e.what() << std::endl;


### PR DESCRIPTION
Symal generates error message "free(): invalid pointer" at end of execution due to bug on line 510. Bug was harmless but best to get rid of it.